### PR TITLE
Add Bootnodes to Chain Spec

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
 import { startNode, startCollator, killAll, generateChainSpec, generateChainSpecRaw } from './spawn';
-import { connect, registerParachain, getHeader, setBalance, changeMaxDownwardMessageSize } from './rpc';
+import { connect, registerParachain, getHeader, setBalance, changeMaxDownwardMessageSize, listenAddresses } from './rpc';
 import { wasmHex } from './wasm';
 import { checkConfig } from './check';
-import { clearAuthorities, addAuthority } from './spec';
+import { clearAuthorities, addAuthority, addBootNodes } from './spec';
 import { parachainAccount } from './parachain';
 
 const { resolve, dirname } = require('path');
@@ -35,71 +35,87 @@ function sleep(ms) {
 }
 
 async function main() {
-	// Verify that the `config.json` has all the expected properties.
-	if (!checkConfig(config)) {
-		return;
-	}
+	try {
+		// Verify that the `config.json` has all the expected properties.
+		if (!checkConfig(config)) {
+			return;
+		}
 
-	const relay_chain_bin = resolve(config_dir, config.relaychain.bin);
-	if (!fs.existsSync(relay_chain_bin)) {
-		console.error("Relay chain binary does not exist: ", relay_chain_bin);
-		process.exit();
-	}
-	const chain = config.relaychain.chain;
-	await generateChainSpec(relay_chain_bin, chain);
-	clearAuthorities(`${chain}.json`);
-	for (const node of config.relaychain.nodes) {
-		await addAuthority(`${chain}.json`, node.name);
-	}
-	await generateChainSpecRaw(relay_chain_bin, chain);
-	const spec = resolve(`${chain}-raw.json`);
-
-	// First we launch each of the validators for the relay chain.
-	for (const node of config.relaychain.nodes) {
-		const { name, wsPort, port, flags } = node;
-		console.log(`Starting ${name}...`);
-		// We spawn a `child_process` starting a node, and then wait until we
-		// able to connect to it using PolkadotJS in order to know its running.
-		startNode(relay_chain_bin, name, wsPort, port, spec, flags);
-	}
-
-	// Then launch each parachain
-	for (const parachain of config.parachains) {
-		const { id, wsPort, port, flags, balance, chain } = parachain;
-		const bin = resolve(config_dir, parachain.bin);
-		if (!fs.existsSync(bin)) {
-			console.error("Parachain binary does not exist: ", bin);
+		const relay_chain_bin = resolve(config_dir, config.relaychain.bin);
+		if (!fs.existsSync(relay_chain_bin)) {
+			console.error("Relay chain binary does not exist: ", relay_chain_bin);
 			process.exit();
 		}
-		let account = parachainAccount(id);
-		console.log(`Starting Parachain ${id}: ${account}`);
-		// This will also create an `<id>.wasm` file in the same directory as `bin`.
-		startCollator(bin, id, wsPort, port, chain, spec, flags)
-	}
-
-	// Then register each parachain on the relay chain.
-	for (const parachain of config.parachains) {
-		const { id, wsPort, port, flags, balance, chain } = parachain;
-		const bin = resolve(config_dir, parachain.bin);
-		let account = parachainAccount(id);
-
-		console.log(`Connecting to Parachain ${id}`);
-		const api = await connect(wsPort, config.types);
-		console.log(`Registering Parachain ${id}`);
-
-		// Get the information required to register the parachain on the relay chain.
-		let header = await getHeader(api);
-		let bin_path = dirname(bin);
-		let wasm = wasmHex(resolve(bin_path, `${id}.wasm`));
-		// Connect to the first relay chain node to submit the extrinsic.
-		let relayChainApi = await connect(config.relaychain.nodes[0].wsPort, config.types);
-		await registerParachain(relayChainApi, id, wasm, header);
-		await changeMaxDownwardMessageSize(relayChainApi, 100);
-		// Allow time for the TX to complete, avoiding nonce issues.
-		// TODO: Handle nonce directly instead of this.
-		if (balance) {
-			await setBalance(relayChainApi, account, balance)
+		const chain = config.relaychain.chain;
+		await generateChainSpec(relay_chain_bin, chain);
+		clearAuthorities(`${chain}.json`);
+		for (const node of config.relaychain.nodes) {
+			await addAuthority(`${chain}.json`, node.name);
 		}
+		await generateChainSpecRaw(relay_chain_bin, chain);
+		const spec = resolve(`${chain}-raw.json`);
+
+		let nodes = config.relaychain.nodes;
+		let first_node = nodes.shift();
+
+		// Launch the first node
+		const { name, wsPort, port, flags } = first_node;
+		console.log(`Starting ${name}...`);
+		startNode(relay_chain_bin, name, wsPort, port, spec, flags);
+		let relayChainApi = await connect(wsPort, config.types);
+
+		// We get listen address
+		let addresses = await listenAddresses(relayChainApi);
+		await addBootNodes(`${chain}-raw.json`, addresses);
+		const spec_bootnode = resolve(`${chain}-raw.json`);
+
+		// Then we launch the rest with the correct boot node
+		for (const node of nodes) {
+			const { name, wsPort, port, flags } = node;
+			console.log(`Starting ${name}...`);
+			// We spawn a `child_process` starting a node, and then wait until we
+			// able to connect to it using PolkadotJS in order to know its running.
+			startNode(relay_chain_bin, name, wsPort, port, spec_bootnode, flags);
+		}
+
+		// Then launch each parachain w/ bootnode
+		for (const parachain of config.parachains) {
+			const { id, wsPort, port, flags, balance, chain } = parachain;
+			const bin = resolve(config_dir, parachain.bin);
+			if (!fs.existsSync(bin)) {
+				console.error("Parachain binary does not exist: ", bin);
+				process.exit();
+			}
+			let account = parachainAccount(id);
+			console.log(`Starting Parachain ${id}: ${account}`);
+			// This will also create an `<id>.wasm` file in the same directory as `bin`.
+			startCollator(bin, id, wsPort, port, chain, spec_bootnode, flags)
+		}
+
+		// Then register each parachain on the relay chain.
+		for (const parachain of config.parachains) {
+			const { id, wsPort, port, flags, balance, chain } = parachain;
+			const bin = resolve(config_dir, parachain.bin);
+			let account = parachainAccount(id);
+
+			console.log(`Connecting to Parachain ${id}`);
+			const api = await connect(wsPort, config.types);
+			console.log(`Registering Parachain ${id}`);
+
+			// Get the information required to register the parachain on the relay chain.
+			let header = await getHeader(api);
+			let bin_path = dirname(bin);
+			let wasm = wasmHex(resolve(bin_path, `${id}.wasm`));
+			await registerParachain(relayChainApi, id, wasm, header);
+			await changeMaxDownwardMessageSize(relayChainApi, 100);
+			// Allow time for the TX to complete, avoiding nonce issues.
+			// TODO: Handle nonce directly instead of this.
+			if (balance) {
+				await setBalance(relayChainApi, account, balance)
+			}
+		}
+	} catch(e) {
+		console.error(e);
 	}
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -92,6 +92,9 @@ async function main() {
 			startCollator(bin, id, wsPort, port, chain, spec_bootnode, flags)
 		}
 
+		// Change the max downward message size for the relay chain
+		await changeMaxDownwardMessageSize(relayChainApi, 100);
+
 		// Then register each parachain on the relay chain.
 		for (const parachain of config.parachains) {
 			const { id, wsPort, port, flags, balance, chain } = parachain;
@@ -107,7 +110,6 @@ async function main() {
 			let bin_path = dirname(bin);
 			let wasm = wasmHex(resolve(bin_path, `${id}.wasm`));
 			await registerParachain(relayChainApi, id, wasm, header);
-			await changeMaxDownwardMessageSize(relayChainApi, 100);
 			// Allow time for the TX to complete, avoiding nonce issues.
 			// TODO: Handle nonce directly instead of this.
 			if (balance) {

--- a/src/rpc.js
+++ b/src/rpc.js
@@ -24,10 +24,10 @@ export async function connect(port, types) {
 	return api;
 }
 
-// Get the PeerId for a running node. Can be used when defining bootnodes for future nodes.
-export async function peerId(api) {
-	let peerId = await api.rpc.system.localPeerId();
-	return peerId.toString();
+// Get the Listen Address for a running node. Can be used when defining boot nodes for future nodes.
+export async function listenAddresses(api) {
+	let listenAddresses = await api.rpc.system.localListenAddresses();
+	return listenAddresses.toJSON();
 }
 
 // Track and display basic information about a chain each block it produces.

--- a/src/spawn.js
+++ b/src/spawn.js
@@ -45,6 +45,7 @@ export async function generateChainSpecRaw(bin, chain) {
 			"build-spec",
 			"--chain=" + chain + '.json',
 			"--raw",
+			"--disable-default-bootnode",
 		];
 
 		p['spec'] = spawn(bin, args);

--- a/src/spec.js
+++ b/src/spec.js
@@ -46,3 +46,12 @@ export async function addAuthority(spec, name) {
 	fs.writeFileSync(spec, data);
 	console.log(`Added Authority ${name}`);
 }
+
+export async function addBootNodes(spec, addresses) {
+	let rawdata = fs.readFileSync(spec);
+	let chainSpec = JSON.parse(rawdata);
+	chainSpec.bootNodes = addresses;
+	let data = JSON.stringify(chainSpec, null, 2);
+	fs.writeFileSync(spec, data);
+	console.log(`Added Boot Nodes: ${addresses}`);
+}


### PR DESCRIPTION
This launches the first relay chain node ahead of the others, and adds it's peer information to bootstrap other nodes as a boot node.